### PR TITLE
Fix for intel mac configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow >= 2.9.0; sys_platform != 'darwin'
-tensorflow-macos >= 2.9.0; sys_platform == 'darwin'
+tensorflow >= 2.9.0; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform_machine != 'arm')
+tensorflow-macos >= 2.9.0; sys_platform == 'darwin' and platform_machine == 'arm'
 absl-py >= 0.1.6


### PR DESCRIPTION
When working on Intel Macbook there is an error that `tensorflow-macos` can't be installed because there are no distributions, so the normal `tensorflow` has to be installed